### PR TITLE
Revert webpack caching

### DIFF
--- a/config/webpack.base.js
+++ b/config/webpack.base.js
@@ -18,8 +18,7 @@ module.exports = {
         ],
     },
     output: {
-        filename: 'js/[name].[hash].js',
-        chunkFilename: 'js/[name].[hash].js',
+        filename: 'js/[name].js',
         path: path.resolve(__dirname, '../build/client'),
     },
     resolve: {

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -22,8 +22,6 @@ module.exports = merge.smart(config, {
         client: ['client'],
     },
     output: {
-        filename: 'js/[name].[chunkhash].js',
-        chunkFilename: 'js/[name].[chunkhash].js',
         publicPath: getPublicPath(),
     },
     plugins: [
@@ -37,7 +35,6 @@ module.exports = merge.smart(config, {
         new webpack.DefinePlugin(GLOBALS),
         new webpack.NoEmitOnErrorsPlugin(),
         new ExtractTextPlugin('css/[name].css'),
-        new webpack.HashedModuleIdsPlugin(),
         new webpack.optimize.UglifyJsPlugin({
             comments: false,
             mangle: false,


### PR DESCRIPTION
This fixes a weird issue i ran into where on non-root routes only, after one or more HMRs, a hard reload resulted in HMRs kicking in sequentially for each change made. Not sure what exactly caused this, but reverting this fixes it. Maybe no need to revert this on prod?